### PR TITLE
docs: Correct PufferPanel naming and expand it's pros

### DIFF
--- a/docs/hosting/panels.mdx
+++ b/docs/hosting/panels.mdx
@@ -91,7 +91,7 @@ Pterodactyl boasts a two part setup, a web-server and a docker agent (wings) tha
 
 PufferPanel could have been the Pterodactyl industry standard tool today, a panel formerly developed by a Pterodactyl team member prior to a clashing of heads and a splitting of the product, however PufferPanel remains open source and in active development by the original founder and an long-time dev. 
 
-The situation is the same for Puffer as it is for Pterodactyl, only has official support for Linux, however Windows builds are available (if unsupported).
+The situation is the same for PufferPanel as it is for Pterodactyl, only has official support for Linux, however Windows builds are available (if unsupported).
 
 #### Pros
 - One click/line installers via APT/YUM
@@ -104,7 +104,7 @@ The situation is the same for Puffer as it is for Pterodactyl, only has official
 - No billing modules
 
 :::note
-Pufferpanel (OSS Project) should not be confused with the proprietary puffer panel used by https://pufferfish.host, **these are two separate entities**.
+PufferPanel (OSS Project) should not be confused with the proprietary puffer panel used by https://pufferfish.host, **these are two separate entities**.
 :::
 
 <div>

--- a/docs/hosting/panels.mdx
+++ b/docs/hosting/panels.mdx
@@ -12,7 +12,7 @@ The top 4 shortlisted panels this article will be covering are.
 - AMP
 - Multicraft
 - Pterodactyl
-- Puffer panel
+- PufferPanel
 
 ### AMP
 
@@ -89,18 +89,19 @@ Pterodactyl boasts a two part setup, a web-server and a docker agent (wings) tha
 
 ### PufferPanel
 
-Pufferpanel could have been the Pterodactyl industry standard tool today, a panel formerly developed by Pterodactyl team member(s) prior to a clashing of heads and a splitting of the product however Pufferpanel remains open source and in active development. 
+PufferPanel could have been the Pterodactyl industry standard tool today, a panel formerly developed by a Pterodactyl team member prior to a clashing of heads and a splitting of the product, however PufferPanel remains open source and in active development by the original founder and an long-time dev. 
 
-The situation is the same for Puffer as it is for Pterodactyl, only has official support for Linux but could possibly run in WSL or Docker on Mac and Windows based devices.
+The situation is the same for Puffer as it is for Pterodactyl, only has official support for Linux, however Windows builds are available (if unsupported).
 
 #### Pros
-- One click/line installers
+- One click/line installers via APT/YUM
+- ARM instruction set support
+- Open source product
 
 #### Cons
 - Documentation is sub-par
 - Lack of industry adoption / third party support
 - No billing modules
-- Stale public development on pufferd 
 
 :::note
 Pufferpanel (OSS Project) should not be confused with the proprietary puffer panel used by https://pufferfish.host, **these are two separate entities**.


### PR DESCRIPTION
## Description

PufferPanel's correct name is no space, capital P. It likewise has pros which are listed with other products, but it doesn't share them. It makes it look completely "con-filled".
The con of pufferd likewise hasn't been relevant since v1.x, which is no longer actively developed, and is instead just... the panel.

## Resolved issues

None
