### PR TITLE
docs: Update Minecraft wiki link

### DIFF
--- a/src/content/docs/tools/startup.mdx
+++ b/src/content/docs/tools/startup.mdx
@@ -57,7 +57,7 @@ All JVM flags (with an option to sort for each distribution) can be found [here.
 ### Advanced Minecraft server options
 
 Minecraft also has quite a few startup options that affect the server in some way. Those go _after_ `-jar` in the startup script.
-The following information is from [the wiki](https://minecraft.fandom.com/wiki/Tutorials/Setting_up_a_server#Minecraft_options)
+The following information is from [the wiki](https://minecraft.wiki/w/Tutorials/Setting_up_a_server#Minecraft_options)
 
 #### Minecraft options
 


### PR DESCRIPTION
## Description

The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.
