### PR TITLE
Feat: Add RubyHost to list of SummerHosts

### DIFF
--- a/src/content/docs/hosting/summerhosts.mdx
+++ b/src/content/docs/hosting/summerhosts.mdx
@@ -70,3 +70,4 @@ Disclaimer: Information was accurate at the time of publication and may not refl
 | [UnknownHost](https://unknownhosting.net/) | No publicly available Privacy Policy |
 | [EnvyNodes](https://www.envynodes.xyz/) | No publicly available SLA, improper (discord) checkout |
 | [DHosting](https://host.diekieboy.com/) | No publicly available Terms of Service, Privacy Policy, SLA |
+| [RubyHost](https://rubyhost.net) | Improper Security Protocols, had a massive databreach losing data of all their clients. Owners are also extremely unprofessional, one of which was streaming NSFW content into a VC with minors.  |


### PR DESCRIPTION
## Description

Due to the events that conspired from RubyHost's downfall, I figured it'd be a good idea to add to the list of summerhosts as they have a relatively decent bit of reach.
