### PR TITLE
docs: Update optimisation to keep using eGlow instead of removing it

### DIFF
--- a/src/content/docs/guides/Minecraft/Optimisation/advanced.mdx
+++ b/src/content/docs/guides/Minecraft/Optimisation/advanced.mdx
@@ -13,7 +13,7 @@ The plugin author's optimisation guide is linked below.. The `anti-override` opt
 
 Regarding anti-override, first make sure that none of your plugins mess with the tablist or scoreboard other than TAB itself. Some common culprits might be BetterTeams, eGlow, Paper's collision rules and CMI. 
 
-You will need to modify eGlow in order to take full advantage of this optimization. Note that disabling these settings in eGlow will most likely result in incorrect glow colors. Just like TAB, eGlow has an anti-override feature called `smart-packet-blocker` and a setting called `send-eGlow-team-packets` for team packets. Switch this from true to false to disable them. Once you're done modifying/removing such plugins, make sure `enable-player-collisions` in Paper's configuration is true. After you do that, you can disable player collisions in TAB's config by changing `scoreboard-teams.enable-collisions`.
+You will need to modify eGlow in order to take full advantage of this optimization. Note that disabling these settings in eGlow will most likely result in incorrect glow colors unless you add the placeholder %eglow_glowcolor% at the end of the tagprefix in TAB. Just like TAB, eGlow has an anti-override feature called `smart-packet-blocker` and a setting called `send-eGlow-team-packets` for team packets. Switch this from true to false to disable them. Once you're done modifying/removing such plugins, make sure `enable-player-collisions` in Paper's configuration is true. After you do that, you can disable player collisions in TAB's config by changing `scoreboard-teams.enable-collisions`.
 
 Finally, switch `anti-override` from true to false. If your tablist does not have proper order, an external plugin is probably still modifying the tablist.
 <div>

--- a/src/content/docs/guides/Minecraft/Optimisation/advanced.mdx
+++ b/src/content/docs/guides/Minecraft/Optimisation/advanced.mdx
@@ -13,7 +13,7 @@ The plugin author's optimisation guide is linked below.. The `anti-override` opt
 
 Regarding anti-override, first make sure that none of your plugins mess with the tablist or scoreboard other than TAB itself. Some common culprits might be BetterTeams, eGlow, Paper's collision rules and CMI. 
 
-You will have to remove eGlow in order to take full advantage of this optimisation. Once you're done modifying/removing such plugins, make sure `enable-player-collisions` in Paper's configuration is true. After you do that, you can disable player collisions in TAB's config by changing `scoreboard-teams.enable-collisions`.
+You will need to modify eGlow in order to take full advantage of this optimization. Note that disabling these settings in eGlow will most likely result in incorrect glow colors. Just like TAB, eGlow has an anti-override feature called `smart-packet-blocker` and a setting called `send-eGlow-team-packets` for team packets. Switch this from true to false to disable them. Once you're done modifying/removing such plugins, make sure `enable-player-collisions` in Paper's configuration is true. After you do that, you can disable player collisions in TAB's config by changing `scoreboard-teams.enable-collisions`.
 
 Finally, switch `anti-override` from true to false. If your tablist does not have proper order, an external plugin is probably still modifying the tablist.
 <div>


### PR DESCRIPTION
## Description

Hello, as the current developer of eGlow I'd like to propose a change in the documentation as currently it states to remove eGlow while it can be modified to disable the features. Although that this will cause incorrect glow colors unless TAB groups/users are reconfigured (which I also included). I think it's better to explain how to disable these parts in eGlow rather than saying to remove it fully.

## Resolved issues

NA

### Before submitting the PR, please take the following into consideration
- [  ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [ X ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [ X ] The description should clearly illustrate what problems it solves.
- [ X ] Ensure that the commit messages follow our guidelines.
- [ X ] Resolve merge conflicts (if any).
- [ X ] Make sure that the current branch is upto date with the `main` branch.
