### PR TITLE
refactor: implement topics dropdown in old sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -111,7 +111,7 @@ export default defineConfig({
         ])
       ],
       components: {
-        Sidebar: './src/components/sidebar.astro',
+        Sidebar: './src/components/Sidebar.astro',
       },
       title: "setup.md",
       customCss: [

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,24 @@
+---
+import Default from '@astrojs/starlight/components/Sidebar.astro';
+import Search from '@astrojs/starlight/components/Search.astro';
+import SiteTitle from '@astrojs/starlight/components/SiteTitle.astro';
+import MobileMenuFooter from '@astrojs/starlight/components/MobileMenuFooter.astro';
+import config from 'virtual:starlight/user-config';
+import { TopicsDropdown } from 'starlight-sidebar-topics-dropdown';
+
+const shouldRenderSearch = config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
+---
+
+{/* (STARLIGHT-THEME-OBSIDIAN): Reorder site sidebar to always contain site title */}
+<div class="sidebar-top">
+    <div class="title-wrapper ">
+        <SiteTitle/>
+    </div>
+
+    <TopicsDropdown />
+    {shouldRenderSearch && <Search/>}
+
+    <MobileMenuFooter/>
+</div>
+
+<Default><slot /></Default>

--- a/src/components/sidebar.astro
+++ b/src/components/sidebar.astro
@@ -1,9 +1,0 @@
----
-import Default from '@astrojs/starlight/components/Sidebar.astro';
-import TopicsDropdown from 'starlight-sidebar-topics-dropdown/TopicsDropdown.astro';
----
-
-{/* Render the topics dropdown menu. */}
-<TopicsDropdown />
-{/* Render the default sidebar. */}
-<Default><slot /></Default>


### PR DESCRIPTION
This PR brings back the old sidebar while retaining the new topics dropdown feature.